### PR TITLE
Fix readdir_r deprecated  issue in kernel 4.8  and gcc 6.2 

### DIFF
--- a/kvm-ipc.c
+++ b/kvm-ipc.c
@@ -137,7 +137,7 @@ int kvm__enumerate_instances(int (*callback)(const char *name, int fd))
 {
 	int sock;
 	DIR *dir;
-	struct dirent entry, *result;
+	struct dirent * entry ;
 	int ret = 0;
 	const char *path;
 
@@ -148,25 +148,24 @@ int kvm__enumerate_instances(int (*callback)(const char *name, int fd))
 		return -errno;
 
 	for (;;) {
-		readdir_r(dir, &entry, &result);
-		if (result == NULL)
-			break;
-		if (is_socket(path, &entry)) {
-			ssize_t name_len = strlen(entry.d_name);
+		entry = readdir_r(dir);
+		
+		if (is_socket(path, entry)) {
+			ssize_t name_len = strlen(entry->d_name);
 			char *p;
 
 			if (name_len <= KVM_SOCK_SUFFIX_LEN)
 				continue;
 
-			p = &entry.d_name[name_len - KVM_SOCK_SUFFIX_LEN];
+			p = &entry->d_name[name_len - KVM_SOCK_SUFFIX_LEN];
 			if (memcmp(KVM_SOCK_SUFFIX, p, KVM_SOCK_SUFFIX_LEN))
 				continue;
 
 			*p = 0;
-			sock = kvm__get_sock_by_instance(entry.d_name);
+			sock = kvm__get_sock_by_instance(entry->d_name);
 			if (sock < 0)
 				continue;
-			ret = callback(entry.d_name, sock);
+			ret = callback(entry->d_name, sock);
 			close(sock);
 			if (ret < 0)
 				break;

--- a/kvm-ipc.c
+++ b/kvm-ipc.c
@@ -148,7 +148,7 @@ int kvm__enumerate_instances(int (*callback)(const char *name, int fd))
 		return -errno;
 
 	for (;;) {
-		entry = readdir_r(dir);
+		entry = readdir(dir);
 		
 		if (is_socket(path, entry)) {
 			ssize_t name_len = strlen(entry->d_name);


### PR DESCRIPTION
I try to build the tool under kernel 4.8 and gcc 6.2 . compiler complained "readdir_r deprecated ", after port to readdir ,  the build is successfully complete. 
